### PR TITLE
Add Support for AAC Stream

### DIFF
--- a/background.html
+++ b/background.html
@@ -5,7 +5,10 @@
   <title>NPR - Background Page</title>
 </head>
 <body>
-  <audio id="npr" src="https://nprdmp-live01-mp3.akacast.akamaistream.net/7/998/364916/v1/npr.akacast.akamaistream.net/nprdmp_live01_mp3"></audio>
+  <audio id="npr">
+    <source src="https://nprdmp-live01-aac.akacast.akamaistream.net/7/91/364917/v1/npr.akacast.akamaistream.net/nprdmp_live01_aac" type="audio/aac" />
+    <source src="https://nprdmp-live01-mp3.akacast.akamaistream.net/7/998/364916/v1/npr.akacast.akamaistream.net/nprdmp_live01_mp3" type="audio/mpeg" />
+  </audio>
   <script src="background.js"></script>
 </body>
 </html>

--- a/background.js
+++ b/background.js
@@ -1,13 +1,21 @@
 const npr = document.getElementById('npr');
 
 function start() {
+  reset();
   npr.play();
 }
 
 function stop() {
   npr.pause();
+  reset();
 }
 
 function checkIfPlaying() {
   return !npr.paused;
+}
+
+function reset() {
+  const stream = npr.innerHTML;
+  npr.innerHTML = '';
+  npr.innerHTML = stream;
 }

--- a/background.js
+++ b/background.js
@@ -1,21 +1,13 @@
 const npr = document.getElementById('npr');
 
 function start() {
-  reset();
   npr.play();
 }
 
 function stop() {
   npr.pause();
-  reset();
 }
 
 function checkIfPlaying() {
   return !npr.paused;
-}
-
-function reset() {
-  const stream = npr.src;
-  npr.src = '';
-  npr.src = stream;
 }


### PR DESCRIPTION
Adds support for the higher-quality and lower-bandwidth AAC stream (of the same content), with the MP3 stream as a fallback. Uses the HTML5 `source` elements inside the `audio` element [(MDN reference)](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/audio#%3Caudio%3E_with_multiple_%3Csource%3E_elements).